### PR TITLE
[WPEWebKit] Use the 2.38 version as a default one

### DIFF
--- a/package/wpewebkit-ml/Config.in
+++ b/package/wpewebkit-ml/Config.in
@@ -65,7 +65,7 @@ config BR2_PACKAGE_WPEWEBKIT_ML
 if BR2_PACKAGE_WPEWEBKIT_ML
 choice
         bool "version"
-        default BR2_PACKAGE_WPEWEBKIT_ML2_46
+        default BR2_PACKAGE_WPEWEBKIT_ML2_38
         help
           Choose the WPEWEBKIT version to be built.
 


### PR DESCRIPTION
As far as I know, WebKitBrowser is not yet compatible with version 2.46 of WPEWebKit, thus leading to crashes. Also, we are using version 2.38 for testing of both Debug as well as Release builds, so it is probably best to have that as default